### PR TITLE
Add /healthz check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ LABEL \
   Maintainer="infra@lists.jenkins-ci.org"
 
 COPY conf.d/nginx.conf /etc/nginx/nginx.conf
+COPY conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY html/ /usr/share/nginx/html/

--- a/conf.d/default.conf
+++ b/conf.d/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen       80; 
+    server_name  default_server;
+        
+    location / { 
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+        
+    location /healthz {
+        access_log off;
+        return 200 "OK\n";
+        add_header Content-Type text/plain;
+    }
+}
+


### PR DESCRIPTION
The nginx ingress default backend required the /healthz to validate if the container is up and running
As defined [here](https://github.com/helm/charts/blob/8d0cd3ceee4a8d761375ec45e112e01467fb4e4e/stable/nginx-ingress/templates/default-backend-deployment.yaml#L58) 